### PR TITLE
Better KCP library

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dgram": "^1.0.1",
     "express": "^4.18.1",
     "mongodb": "^4.8.0",
-    "node-kcp-token": "github:memetrollsxd/node-kcp",
+    "node-kcp-x": "1.0.1",
     "protobufjs": "^7.0.0",
     "typescript": "^4.7.4"
   }


### PR DESCRIPTION
This PR replaces @memetrollsXD's KCP library with `node-kcp-x`.